### PR TITLE
Shadow wrap

### DIFF
--- a/source/Level.hx
+++ b/source/Level.hx
@@ -76,14 +76,24 @@ class Level extends FlxGroup {
     // finish level tile
     tilemap.setTileProperties(3, FlxObject.NONE);
 
+    var shadowTileArray:Array<Int> = [];
+    for (y in 0...map.height) {
+      var i:Int = y * map.width;
+      shadowTileArray.push(solidLayer.tileArray[i + map.width - 1]);
+      for (x in 0...map.width) {
+        shadowTileArray.push(solidLayer.tileArray[i + x]);
+      }
+    }
+
     shadowTilemap = new FlxTilemap();
-    shadowTilemap.loadMapFromArray(solidLayer.tileArray,
-                                   map.width,
+    shadowTilemap.loadMapFromArray(shadowTileArray,
+                                   map.width + 1,
                                    map.height,
                                    AssetPaths.tileset_shadow__png,
                                    16, 16, 1);
 
     shadowTilemap.x = shadowTilemap.y = 4;
+    shadowTilemap.x -= 16;
 
     add(shadowTilemap);
     add(player);


### PR DESCRIPTION
Here's a picture of the current main level:

![Main level](https://cloud.githubusercontent.com/assets/9948030/25314368/f47a7f7e-2818-11e7-9d65-f488551718f1.png)

Look on the left side of the level:

![Left side with incomplete shadows](https://cloud.githubusercontent.com/assets/9948030/25314375/061f9f16-2819-11e7-8277-690ed013c624.png)

In a wrapping world such as the one we've built, the shadows of blocks from the right side would wrap to the left side. However, they don't. This PR makes those shadows do so:

![screen shot 2017-04-23 at 11 37 49 am](https://cloud.githubusercontent.com/assets/9948030/25314390/4db155d6-2819-11e7-8a37-6d42eea3fd12.png)

