### PR TITLE
Vertical wrap for shadows

### DIFF
--- a/source/Level.hx
+++ b/source/Level.hx
@@ -77,6 +77,14 @@ class Level extends FlxGroup {
     tilemap.setTileProperties(3, FlxObject.NONE);
 
     var shadowTileArray:Array<Int> = [];
+
+    shadowTileArray.push(solidLayer.tileArray[map.height * map.width - 1]);
+    for (x in 0...map.width) {
+      var i:Int = (map.height - 1) * map.width + x;
+      // var i:Int = x;
+      shadowTileArray.push(solidLayer.tileArray[i]);
+    }
+
     for (y in 0...map.height) {
       var i:Int = y * map.width;
       shadowTileArray.push(solidLayer.tileArray[i + map.width - 1]);
@@ -88,12 +96,11 @@ class Level extends FlxGroup {
     shadowTilemap = new FlxTilemap();
     shadowTilemap.loadMapFromArray(shadowTileArray,
                                    map.width + 1,
-                                   map.height,
+                                   map.height + 1,
                                    AssetPaths.tileset_shadow__png,
                                    16, 16, 1);
 
-    shadowTilemap.x = shadowTilemap.y = 4;
-    shadowTilemap.x -= 16;
+    shadowTilemap.x = shadowTilemap.y = 4 - 16;
 
     add(shadowTilemap);
     add(player);


### PR DESCRIPTION
The same deal as #2, but with a vertical wrap:

![Demo](https://cloud.githubusercontent.com/assets/9948030/25318003/e7c59c26-285b-11e7-80bb-355d6151db86.png)

As you can see, the bottom tile drops its shadow above the tile on the top.
